### PR TITLE
Add zstd build script

### DIFF
--- a/zstd/build.sh
+++ b/zstd/build.sh
@@ -5,6 +5,11 @@ recipe_dir=$(dirname $(realpath $0))
 version=${1:?}
 
 cd $recipe_dir
+
+# zstd was added to Python in version 3.14, which uses this minimum API level.
+# zstd also requires the same API level for fseeko and ftello on 32-bit ABIs
+# (https://android.googlesource.com/platform/bionic/+/HEAD/docs/32-bit-abi.md).
+ANDROID_API_LEVEL=24
 . ../android-env.sh
 
 version_dir=$recipe_dir/build/$version

--- a/zstd/build.sh
+++ b/zstd/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eu
+
+recipe_dir=$(dirname $(realpath $0))
+version=${1:?}
+
+cd $recipe_dir
+. ../android-env.sh
+
+version_dir=$recipe_dir/build/$version
+mkdir -p $version_dir
+cd $version_dir
+src_filename=zstd-$version.tar.gz
+wget -c https://github.com/facebook/zstd/releases/download/v$version/$src_filename
+
+build_dir=$version_dir/$HOST
+rm -rf $build_dir
+mkdir $build_dir
+cd $build_dir
+tar -xf $version_dir/$src_filename
+cd zstd-$version
+
+prefix=$build_dir/prefix
+mkdir $prefix
+
+make -j $CPU_COUNT lib-release PREFIX=$prefix
+make install PREFIX=$prefix


### PR DESCRIPTION
This PR adds a build script for libzstd. It's based on the xz build script, but zstd just uses 

## PR Checklist:
- [x] All new features have been tested
- [x] ~~All new features have been documented~~ n/a I think?
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

I tested building this with the ndk and was able to build zstd and uploaded the resulting tar.gz to my server: https://static.0xe.me/zstd-1.5.7-0-aarch64-linux-android.tar.gz

Part of https://github.com/python/cpython/issues/135846. Once this is merged we can update android.py in the CPython repo.

